### PR TITLE
Update theme.txt

### DIFF
--- a/manjaro-live/theme.txt
+++ b/manjaro-live/theme.txt
@@ -41,8 +41,8 @@ terminal-border: "0"
     item_color = "#cccccc"
     #item_color = "#FFA2A2"
     selected_item_font = "Terminus 16"
-    selected_item_color = "#ffffff"
-    selected_item_pixmap_style = "select_*.png"
+    selected_item_color = "#1ABB9B"
+    #selected_item_pixmap_style = "select_*.png"
     menu_pixmap_style = "menu_*.png"
 }
 


### PR DESCRIPTION
Use font color instead of pixmap to highlight items.

This change has the advantage of text not jumping. 

I tried modifying the images and different item heights, but in the end this was the only option that bought an end to the jumping of text.